### PR TITLE
Add new fields `metadata` & `store` in CreateChatCompletionRequest

### DIFF
--- a/async-openai/src/types/chat.rs
+++ b/async-openai/src/types/chat.rs
@@ -393,6 +393,14 @@ pub struct CreateChatCompletionRequest {
     /// See the [model endpoint compatibility](https://platform.openai.com/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
     pub model: String,
 
+    /// Whether or not to store the output of this chat completion request for use in [model distillation](https://platform.openai.com/docs/guides/distillation) or [evals](https://platform.openai.com/docs/guides/evals) products.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+
+    /// Developer-defined tags and values used for filtering completions. 
+    /// #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+
     /// Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim.
     ///
     /// [See more information about frequency and presence penalties.](https://platform.openai.com/docs/api-reference/parameter-details)
@@ -416,11 +424,15 @@ pub struct CreateChatCompletionRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_logprobs: Option<u8>,
 
-    /// The maximum number of [tokens](https://platform.openai.com/tokenizer) that can be generated in the chat completion.
-    ///
-    /// The total length of input tokens and generated tokens is limited by the model's context length. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
+    /// The maximum number of tokens that can be generated in the chat completion. This value can be used to control costs for text generated via API.
+    /// This value is now **deprecated** in favor of max_completion_tokens, and is not compatible with o1 series models.
+    #[deprecated]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+
+    /// An upper bound for the number of tokens that can be generated for a completion, including visible output tokens and reasoning tokens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<u32>,
 
     /// How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs.
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## 🗣 Description
 - New fields `metadata` and `store` have been added to the `CreateChatCompletionRequest` struct in the `chat.rs` file.
 - Also mark `max_tokens` as deprecated in favour of the new field `max_completion_tokens`.