### PR TITLE
Fix code interpreter output schema

### DIFF
--- a/async-openai/src/types/responses.rs
+++ b/async-openai/src/types/responses.rs
@@ -1184,15 +1184,17 @@ pub struct ImageGenerationCallOutput {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CodeInterpreterCallOutput {
     /// The code that was executed.
-    pub code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
     /// Unique ID of the call.
     pub id: String,
     /// Status of the tool call.
     pub status: String,
     /// ID of the container used to run the code.
     pub container_id: String,
-    /// The results of the execution: logs or files.
-    pub results: Vec<CodeInterpreterResult>,
+    /// The outputs of the execution: logs or files.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outputs: Option<Vec<CodeInterpreterResult>>,
 }
 
 /// Individual result from a code interpreter: either logs or files.


### PR DESCRIPTION
## 🗣 Description
- This PR fixes the schema of the code interpreter output to match that specified by OpenAI's documentation
Schema:
<img width="1314" height="1178" alt="image" src="https://github.com/user-attachments/assets/45c6dd77-c602-4419-afd6-f91060f0d9a1" />

