### PR TITLE
Add serde attribute to omit None values for include_usage and include_obfuscation

### DIFF
--- a/async-openai/src/types/chat/chat_.rs
+++ b/async-openai/src/types/chat/chat_.rs
@@ -1029,6 +1029,7 @@ pub struct ChatCompletionStreamOptions {
     /// All other chunks will also include a `usage` field, but with a null
     /// value. **NOTE:** If the stream is interrupted, you may not receive the
     /// final usage chunk which contains the total token usage for the request.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub include_usage: Option<bool>,
 
     /// When true, stream obfuscation will be enabled. Stream obfuscation adds
@@ -1038,6 +1039,7 @@ pub struct ChatCompletionStreamOptions {
     /// of overhead to the data stream. You can set `include_obfuscation` to
     /// false to optimize for bandwidth if you trust the network links between
     /// your application and the OpenAI API.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub include_obfuscation: Option<bool>,
 }
 

--- a/async-openai/tests/ser_de.rs
+++ b/async-openai/tests/ser_de.rs
@@ -1,6 +1,6 @@
 use async_openai::types::chat::{
     ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
-    CreateChatCompletionRequest, CreateChatCompletionRequestArgs,
+    ChatCompletionStreamOptions, CreateChatCompletionRequest, CreateChatCompletionRequestArgs,
 };
 
 #[test]
@@ -25,4 +25,38 @@ fn chat_types_serde() {
     // deserialize the request
     let deserialized: CreateChatCompletionRequest = serde_json::from_str(&serialized).unwrap();
     assert_eq!(request, deserialized);
+}
+
+#[test]
+fn stream_options_none_fields_not_serialized() {
+    // When include_obfuscation is None, it should not appear in the serialized JSON.
+    // This is important for OpenAI-compatible providers (like NVIDIA NIM) that reject unknown fields.
+    let stream_options = ChatCompletionStreamOptions {
+        include_usage: Some(true),
+        include_obfuscation: None,
+    };
+
+    let serialized = serde_json::to_string(&stream_options).unwrap();
+
+    // Verify include_usage is present
+    assert!(serialized.contains("include_usage"));
+    // Verify include_obfuscation is NOT present (not even as null)
+    assert!(
+        !serialized.contains("include_obfuscation"),
+        "include_obfuscation should not be serialized when None, but got: {}",
+        serialized
+    );
+
+    // Test when both are None
+    let stream_options_empty = ChatCompletionStreamOptions {
+        include_usage: None,
+        include_obfuscation: None,
+    };
+
+    let serialized_empty = serde_json::to_string(&stream_options_empty).unwrap();
+    assert_eq!(serialized_empty, "{}");
+
+    // Test roundtrip deserialization
+    let deserialized: ChatCompletionStreamOptions = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(stream_options, deserialized);
 }


### PR DESCRIPTION
## 🗣 Description

Add serde attribute to omit None values for include_usage and include_obfuscation. Add tests to verify correct serialization and deserialization behavior.

This pull request improves the serialization behavior of the `ChatCompletionStreamOptions` struct in the `async-openai` crate to ensure that optional fields are omitted from JSON output when they are `None`. This is important for compatibility with OpenAI-compatible providers that may reject unknown or null fields. Additionally, a new test has been added to verify this behavior.

Serialization improvements:

* Added `#[serde(skip_serializing_if = "Option::is_none")]` attributes to the `include_usage` and `include_obfuscation` fields in the `ChatCompletionStreamOptions` struct so that these fields are not serialized when set to `None`. [[1]](diffhunk://#diff-76fbd3ccc66c49164c723245520fc64468b15f27edc10353f6156f663c35f469R1032) [[2]](diffhunk://#diff-76fbd3ccc66c49164c723245520fc64468b15f27edc10353f6156f663c35f469R1042)

Testing:

* Added a unit test `stream_options_none_fields_not_serialized` in `async-openai/tests/ser_de.rs` to ensure that optional fields are omitted from the serialized JSON when they are `None`, and to check roundtrip serialization/deserialization.
* Updated imports in `ser_de.rs` to include `ChatCompletionStreamOptions`.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
