### PR TITLE
Make `EasyInputMessage.type` optional

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -212,6 +212,10 @@ name = "ser_de"
 required-features = ["chat-completion-types"]
 
 [[test]]
+name = "responses_ser_de"
+required-features = ["response-types"]
+
+[[test]]
 name = "whisper"
 required-features = ["audio"]
 

--- a/async-openai/src/types/responses/response.rs
+++ b/async-openai/src/types/responses/response.rs
@@ -362,6 +362,7 @@ pub struct CustomToolCallOutput {
 #[builder(build_fn(error = "OpenAIError"))]
 pub struct EasyInputMessage {
     /// The type of the message input. Always set to `message`.
+    #[serde(default)]
     pub r#type: MessageType,
     /// The role of the message input. One of `user`, `assistant`, `system`, or `developer`.
     pub role: Role,

--- a/async-openai/tests/responses_ser_de.rs
+++ b/async-openai/tests/responses_ser_de.rs
@@ -1,0 +1,16 @@
+use async_openai::types::responses::{EasyInputMessage, MessageType, Role};
+
+#[test]
+fn easy_input_message_type_defaults_when_missing() {
+    // `type` is omitted — should default to MessageType::Message via #[serde(default)]
+    let json = r#"{"role":"user","content":"hello"}"#;
+    let msg: EasyInputMessage = serde_json::from_str(json).unwrap();
+    assert_eq!(msg.r#type, MessageType::Message);
+    assert_eq!(msg.role, Role::User);
+
+    // `type` present — should round-trip unchanged
+    let json_with_type = r#"{"type":"message","role":"user","content":"hello"}"#;
+    let msg2: EasyInputMessage = serde_json::from_str(json_with_type).unwrap();
+    assert_eq!(msg2.r#type, MessageType::Message);
+    assert_eq!(msg, msg2);
+}


### PR DESCRIPTION
## 🗣 Description

Make `EasyInputMessage.type` optional in Responses API. This is needed for integration with OpenClaw - since this field is skipped.