### PR TITLE
Bump reqwest to 0.13

### DIFF
--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -171,7 +171,7 @@ reqwest = { version = "0.13", features = [
   "multipart",
   "query",
 ], default-features = false, optional = true }
-reqwest-eventsource = { git = "https://github.com/spiceai/reqwest-eventsource", rev = "eb11e695128ce264bf05e4220ce2311c25992c73", optional = true }
+reqwest-eventsource = { git = "https://github.com/spiceai/reqwest-eventsource", rev = "eb11e695128ce264bf05e4220ce2311c25992c73", optional = true } # branch: spiceai
 thiserror = { version = "2", optional = true }
 tokio = { version = "1", features = ["fs", "macros"], optional = true }
 tokio-stream = { version = "0.1", optional = true }

--- a/async-openai/Cargo.toml
+++ b/async-openai/Cargo.toml
@@ -15,9 +15,9 @@ repository = "https://github.com/64bit/async-openai"
 [features]
 default = ["rustls"]
 # Enable rustls for TLS support
-rustls = ["dep:reqwest", "reqwest/rustls-tls-native-roots"]
-# Enable rustls and webpki-roots
-rustls-webpki-roots = ["dep:reqwest", "reqwest/rustls-tls-webpki-roots"]
+rustls = ["dep:reqwest", "reqwest/rustls"]
+# Enable rustls (reqwest 0.13 uses rustls-platform-verifier; webpki-roots is no longer a separate reqwest feature)
+rustls-webpki-roots = ["dep:reqwest", "reqwest/rustls"]
 # Enable native-tls for TLS support
 native-tls = ["dep:reqwest", "reqwest/native-tls"]
 # Remove dependency on OpenSSL
@@ -165,12 +165,13 @@ backoff = { version = "0.4.0", features = ["tokio"], optional = true }
 base64 = { version = "0.22", optional = true }
 futures = { version = "0.3", optional = true }
 rand = { version = "0.9", optional = true }
-reqwest = { version = "0.12", features = [
+reqwest = { version = "0.13", features = [
   "json",
   "stream",
   "multipart",
+  "query",
 ], default-features = false, optional = true }
-reqwest-eventsource = { version = "0.6.0", optional = true }
+reqwest-eventsource = { git = "https://github.com/spiceai/reqwest-eventsource", rev = "eb11e695128ce264bf05e4220ce2311c25992c73", optional = true }
 thiserror = { version = "2", optional = true }
 tokio = { version = "1", features = ["fs", "macros"], optional = true }
 tokio-stream = { version = "0.1", optional = true }

--- a/async-openai/src/types/images/form.rs
+++ b/async-openai/src/types/images/form.rs
@@ -97,23 +97,20 @@ impl AsyncTryFrom<CreateImageVariationRequest> for reqwest::multipart::Form {
             form = form.text("model", model.to_string())
         }
 
-        if request.n.is_some() {
-            form = form.text("n", request.n.unwrap().to_string())
+        if let Some(n) = request.n {
+            form = form.text("n", n.to_string())
         }
 
-        if request.size.is_some() {
-            form = form.text("size", request.size.unwrap().to_string())
+        if let Some(size) = request.size {
+            form = form.text("size", size.to_string())
         }
 
-        if request.response_format.is_some() {
-            form = form.text(
-                "response_format",
-                request.response_format.unwrap().to_string(),
-            )
+        if let Some(response_format) = request.response_format {
+            form = form.text("response_format", response_format.to_string())
         }
 
-        if request.user.is_some() {
-            form = form.text("user", request.user.unwrap())
+        if let Some(user) = request.user {
+            form = form.text("user", user)
         }
         Ok(form)
     }

--- a/async-openai/src/types/videos/form.rs
+++ b/async-openai/src/types/videos/form.rs
@@ -11,16 +11,16 @@ impl AsyncTryFrom<CreateVideoRequest> for reqwest::multipart::Form {
 
         form = form.text("prompt", request.prompt);
 
-        if request.size.is_some() {
-            form = form.text("size", request.size.unwrap().to_string());
+        if let Some(size) = request.size {
+            form = form.text("size", size.to_string());
         }
 
-        if request.seconds.is_some() {
-            form = form.text("seconds", request.seconds.unwrap().to_string());
+        if let Some(seconds) = request.seconds {
+            form = form.text("seconds", seconds.to_string());
         }
 
-        if request.input_reference.is_some() {
-            let image_part = create_file_part(request.input_reference.unwrap().source).await?;
+        if let Some(input_reference) = request.input_reference {
+            let image_part = create_file_part(input_reference.source).await?;
             form = form.part("input_reference", image_part);
         }
 


### PR DESCRIPTION
Bumps `reqwest` from 0.12 to 0.13.

Changes (`async-openai/Cargo.toml` only — no source changes required):
- `reqwest` 0.12 → 0.13, and add the `query` feature (it became opt-in in reqwest 0.13; `client.rs` uses `.query()`).
- Remap the rustls TLS feature passthroughs: reqwest 0.13 dropped `rustls-tls-native-roots`/`rustls-tls-webpki-roots` in favor of `rustls` (aws-lc provider + rustls-platform-verifier). Both `rustls` and `rustls-webpki-roots` now map to `reqwest/rustls`.
- Repoint `reqwest-eventsource` to the spiceai fork (which carries the matching reqwest 0.13 bump), since the crates.io `0.6.0` release is still on reqwest 0.12.

Builds clean with the runtime's feature set (`byot,embedding,chat-completion,responses,model`); clippy clean. The only failing tests are the live-API embedding tests that require `OPENAI_API_KEY` (network), unrelated to this change.

Part of moving the Spice.ai runtime workspace onto reqwest 0.13 for the OpenTelemetry 0.32 upgrade.