### PR TITLE
Aggregate rate-limit retry logging instead of one WARN per request

### DIFF
--- a/async-openai/src/client.rs
+++ b/async-openai/src/client.rs
@@ -503,7 +503,7 @@ impl<C: Config> Client<C> {
     {
         let client = self.http_client.clone();
 
-        backoff::future::retry(self.backoff.clone(), || async {
+        let attempt = || async {
             let request = request_maker().await.map_err(backoff::Error::Permanent)?;
             let response = client
                 .execute(request)
@@ -527,7 +527,7 @@ impl<C: Config> Client<C> {
                                 && api_error.r#type != Some("insufficient_quota".to_string())
                             {
                                 // Rate limited retry...
-                                tracing::warn!("Rate limited: {}", api_error.message);
+                                crate::rate_limit::log_throttled(&api_error.message);
                                 Err(backoff::Error::Transient {
                                     err: OpenAIError::ApiError(api_error),
                                     retry_after: None,
@@ -539,6 +539,14 @@ impl<C: Config> Client<C> {
                         _ => Err(backoff::Error::Permanent(e)),
                     }
                 }
+            }
+        };
+
+        // Attributes the backoff a retry is about to sleep for to the model that
+        // was throttled, for the summary that `log_throttled` emits.
+        backoff::future::retry_notify(self.backoff.clone(), attempt, |err, backoff| {
+            if let OpenAIError::ApiError(api_error) = &err {
+                crate::rate_limit::record_backoff(&api_error.message, backoff);
             }
         })
         .await

--- a/async-openai/src/lib.rs
+++ b/async-openai/src/lib.rs
@@ -273,6 +273,8 @@ mod impls;
 mod model;
 #[cfg(feature = "moderation")]
 mod moderation;
+#[cfg(feature = "_api")]
+mod rate_limit;
 #[cfg(feature = "realtime")]
 mod realtime;
 #[cfg(feature = "_api")]

--- a/async-openai/src/rate_limit.rs
+++ b/async-openai/src/rate_limit.rs
@@ -407,8 +407,7 @@ mod tests {
         );
     }
 
-    /// The organisation id reaches the per-request detail, as it always has, but
-    /// not the summary.
+    /// The organisation id belongs to the per-request detail, not the summary.
     #[test]
     fn the_summary_carries_no_organisation_id() {
         let events = Captured::default();

--- a/async-openai/src/rate_limit.rs
+++ b/async-openai/src/rate_limit.rs
@@ -1,0 +1,491 @@
+//! Aggregated logging for requests that are retried because they were rate limited.
+//!
+//! A saturated quota throttles every request in flight, so logging each one at
+//! `WARN` drowns out the rest of the log. Instead the first throttled request per
+//! model is reported at `WARN`, every later one at `DEBUG`, and a per-model
+//! summary is emitted at `WARN` once per [`AGGREGATE_WINDOW`].
+
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::{Mutex, MutexGuard, OnceLock, PoisonError},
+    time::{Duration, Instant},
+};
+
+/// How long throttled requests are counted for before a summary is emitted.
+const AGGREGATE_WINDOW: Duration = Duration::from_secs(60);
+
+/// Number of models counted separately. Models past this share a single bucket so
+/// that unexpected messages cannot grow the table without end.
+const MAX_TRACKED_MODELS: usize = 32;
+
+/// Bucket for throttled requests whose model could not be determined.
+const UNKNOWN_MODEL: &str = "unknown model";
+
+/// Longest model name given a bucket of its own.
+const MAX_MODEL_LEN: usize = 64;
+
+/// Records a throttled request and logs it, keeping the per-request detail out of
+/// `WARN` once a model's first throttled request has been reported.
+pub(crate) fn log_throttled(message: &str) {
+    log_throttled_at(tracker(), message, Instant::now());
+}
+
+/// Adds the backoff a retry is about to sleep for to its model's running total.
+pub(crate) fn record_backoff(message: &str, backoff: Duration) {
+    record_backoff_on(tracker(), message, backoff);
+}
+
+/// Process-wide throttling state.
+fn tracker() -> &'static Tracker {
+    static TRACKER: OnceLock<Tracker> = OnceLock::new();
+    TRACKER.get_or_init(Tracker::default)
+}
+
+fn log_throttled_at(tracker: &Tracker, message: &str, now: Instant) {
+    let model = model_from_message(message).unwrap_or(UNKNOWN_MODEL);
+    let report = tracker.record(model, now);
+
+    if report.first {
+        tracing::warn!("Rate limited: {message}");
+    } else {
+        tracing::debug!("Rate limited: {message}");
+    }
+
+    if let Some(summary) = report.summary {
+        tracing::warn!(
+            "Rate limited by {model}: {} requests throttled in the last {}s, total backoff {:.1}s",
+            summary.throttled,
+            summary.window.as_secs(),
+            summary.backoff.as_secs_f64(),
+        );
+    }
+}
+
+/// Messages that are not rate-limit messages are ignored, so retries of other
+/// transient errors do not contribute.
+fn record_backoff_on(tracker: &Tracker, message: &str, backoff: Duration) {
+    if let Some(model) = model_from_message(message) {
+        tracker.add_backoff(model, backoff);
+    }
+}
+
+/// Extracts the model from a rate-limit message, which reads
+/// `Rate limit reached for <model> in organization <org> on <quota>: ...`.
+///
+/// Returns `None` for anything that does not match, which keeps the organisation
+/// id out of the summary and confines unrecognised messages to one bucket.
+fn model_from_message(message: &str) -> Option<&str> {
+    let rest = message.strip_prefix("Rate limit reached for ")?;
+    let model = &rest[..rest.find(" in organization ")?];
+    (!model.is_empty() && model.len() <= MAX_MODEL_LEN).then_some(model)
+}
+
+/// Counts throttled requests per model.
+#[derive(Debug, Default)]
+struct Tracker {
+    models: Mutex<HashMap<String, ModelState>>,
+}
+
+impl Tracker {
+    fn record(&self, model: &str, now: Instant) -> Report {
+        let mut models = self.lock();
+
+        // Models past the limit share one bucket, to bound the table.
+        let key = if models.len() < MAX_TRACKED_MODELS || models.contains_key(model) {
+            model
+        } else {
+            UNKNOWN_MODEL
+        };
+
+        match models.entry(key.to_owned()) {
+            Entry::Vacant(entry) => {
+                entry.insert(ModelState::opening(now));
+                Report::first()
+            }
+            Entry::Occupied(mut entry) => {
+                let state = entry.get_mut();
+
+                // A whole window without a throttled request ends the episode, so
+                // the next one is reported afresh.
+                if now.duration_since(state.last) >= AGGREGATE_WINDOW {
+                    *state = ModelState::opening(now);
+                    return Report::first();
+                }
+
+                state.last = now;
+                state.throttled += 1;
+
+                let window = now.duration_since(state.start);
+                if window < AGGREGATE_WINDOW {
+                    return Report::later(None);
+                }
+
+                let summary = Summary {
+                    throttled: state.throttled,
+                    window,
+                    backoff: state.backoff,
+                };
+
+                // This request belongs to the window it closed, so the next window
+                // opens empty.
+                state.start = now;
+                state.throttled = 0;
+                state.backoff = Duration::ZERO;
+
+                Report::later(Some(summary))
+            }
+        }
+    }
+
+    fn add_backoff(&self, model: &str, backoff: Duration) {
+        if let Some(state) = self.lock().get_mut(model) {
+            state.backoff = state.backoff.saturating_add(backoff);
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, HashMap<String, ModelState>> {
+        self.models.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Throttled requests counted for one model since its current window opened.
+#[derive(Debug)]
+struct ModelState {
+    start: Instant,
+    last: Instant,
+    throttled: u64,
+    backoff: Duration,
+}
+
+impl ModelState {
+    /// Opens a window already holding the throttled request being recorded.
+    fn opening(now: Instant) -> Self {
+        Self {
+            start: now,
+            last: now,
+            throttled: 1,
+            backoff: Duration::ZERO,
+        }
+    }
+}
+
+/// What to log for a single throttled request.
+#[derive(Debug, PartialEq, Eq)]
+struct Report {
+    /// Whether this is the first throttled request of an episode, which is
+    /// reported at `WARN` rather than `DEBUG`.
+    first: bool,
+    /// Totals for a window this request closed.
+    summary: Option<Summary>,
+}
+
+impl Report {
+    fn first() -> Self {
+        Self {
+            first: true,
+            summary: None,
+        }
+    }
+
+    fn later(summary: Option<Summary>) -> Self {
+        Self {
+            first: false,
+            summary,
+        }
+    }
+}
+
+/// Totals for one model over a closed window.
+#[derive(Debug, PartialEq, Eq)]
+struct Summary {
+    throttled: u64,
+    window: Duration,
+    backoff: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fmt::Debug,
+        sync::{Arc, Mutex},
+    };
+
+    use tracing::{
+        field::{Field, Visit},
+        span, Event, Level, Metadata, Subscriber,
+    };
+
+    use super::*;
+
+    /// A rate-limit message of the shape OpenAI returns, with the organisation id
+    /// redacted.
+    const TPM_MESSAGE: &str = "Rate limit reached for text-embedding-3-small in organization \
+                               org-redacted on tokens per min (TPM): Limit 10000000, Used \
+                               10000000, Requested 71609. Please try again in 429ms.";
+
+    #[test]
+    fn model_is_read_from_a_rate_limit_message() {
+        assert_eq!(
+            model_from_message(TPM_MESSAGE),
+            Some("text-embedding-3-small")
+        );
+    }
+
+    #[test]
+    fn other_messages_have_no_model() {
+        assert_eq!(model_from_message("You exceeded your current quota."), None);
+        assert_eq!(model_from_message("Rate limit reached for gpt-4"), None);
+        assert_eq!(
+            model_from_message("Rate limit reached for  in organization org-redacted on TPM"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_burst_within_one_window_reports_only_the_first_request() {
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        let reports: Vec<Report> = (0..500)
+            .map(|i| tracker.record("gpt-4", start + Duration::from_millis(i * 100)))
+            .collect();
+
+        assert!(reports[0].first);
+        assert_eq!(reports.iter().filter(|report| report.first).count(), 1);
+        assert!(reports.iter().all(|report| report.summary.is_none()));
+    }
+
+    #[test]
+    fn a_window_closing_summarises_the_requests_it_held() {
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        // One request a second, so the one at 60s closes the window.
+        let reports: Vec<Report> = (0..=60)
+            .map(|i| tracker.record("gpt-4", start + Duration::from_secs(i)))
+            .collect();
+
+        let summaries: Vec<&Summary> = reports
+            .iter()
+            .filter_map(|report| report.summary.as_ref())
+            .collect();
+
+        assert_eq!(reports.iter().filter(|report| report.first).count(), 1);
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].throttled, 61);
+        assert_eq!(summaries[0].window, AGGREGATE_WINDOW);
+    }
+
+    #[test]
+    fn backoff_accumulates_into_the_open_window_only() {
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        tracker.record("gpt-4", start);
+        tracker.add_backoff("gpt-4", Duration::from_millis(400));
+        tracker.record("gpt-4", start + Duration::from_secs(30));
+        tracker.add_backoff("gpt-4", Duration::from_millis(600));
+
+        let report = tracker.record("gpt-4", start + AGGREGATE_WINDOW);
+        let summary = report.summary.expect("the window should have closed");
+        assert_eq!(summary.throttled, 3);
+        assert_eq!(summary.backoff, Duration::from_secs(1));
+
+        // The next window starts empty rather than carrying the total forward.
+        tracker.record("gpt-4", start + AGGREGATE_WINDOW + Duration::from_secs(1));
+        let report = tracker.record("gpt-4", start + AGGREGATE_WINDOW * 2);
+        let summary = report
+            .summary
+            .expect("the second window should have closed");
+        assert_eq!(summary.throttled, 2);
+        assert_eq!(summary.backoff, Duration::ZERO);
+    }
+
+    #[test]
+    fn each_model_is_counted_separately() {
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        assert!(tracker.record("gpt-4", start).first);
+        assert!(tracker.record("text-embedding-3-small", start).first);
+        assert!(
+            !tracker
+                .record("gpt-4", start + Duration::from_secs(1))
+                .first
+        );
+    }
+
+    #[test]
+    fn a_quiet_window_starts_a_new_episode() {
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        tracker.record("gpt-4", start);
+        assert!(
+            !tracker
+                .record("gpt-4", start + Duration::from_secs(1))
+                .first
+        );
+        assert!(
+            tracker
+                .record("gpt-4", start + Duration::from_secs(1) + AGGREGATE_WINDOW)
+                .first
+        );
+    }
+
+    #[test]
+    fn the_table_stays_bounded() {
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        for i in 0..10_000 {
+            tracker.record(&format!("model-{i}"), start);
+        }
+
+        assert!(tracker.lock().len() <= MAX_TRACKED_MODELS + 1);
+    }
+
+    #[test]
+    fn a_flood_of_throttled_requests_logs_one_warning_and_a_summary() {
+        let events = Captured::default();
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        tracing::subscriber::with_default(events.clone(), || {
+            // 500 throttled requests spread evenly over the window, the last of
+            // which closes it.
+            for i in 0..500_u32 {
+                log_throttled_at(&tracker, TPM_MESSAGE, start + AGGREGATE_WINDOW * i / 499);
+            }
+        });
+
+        let warnings = events.at(Level::WARN);
+        assert_eq!(
+            warnings.len(),
+            2,
+            "expected one first-occurrence warning and one summary, got {warnings:#?}"
+        );
+        assert!(warnings[0].starts_with("Rate limited: Rate limit reached for"));
+        assert_eq!(
+            warnings[1],
+            "Rate limited by text-embedding-3-small: 500 requests throttled in the last 60s, \
+             total backoff 0.0s"
+        );
+        assert_eq!(events.at(Level::DEBUG).len(), 499);
+    }
+
+    #[test]
+    fn a_summary_reports_the_backoff_spent_waiting() {
+        let events = Captured::default();
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        tracing::subscriber::with_default(events.clone(), || {
+            log_throttled_at(&tracker, TPM_MESSAGE, start);
+            record_backoff_on(&tracker, TPM_MESSAGE, Duration::from_millis(1100));
+            log_throttled_at(&tracker, TPM_MESSAGE, start + Duration::from_secs(30));
+            record_backoff_on(&tracker, TPM_MESSAGE, Duration::from_millis(400));
+            log_throttled_at(&tracker, TPM_MESSAGE, start + AGGREGATE_WINDOW);
+        });
+
+        assert_eq!(
+            events.at(Level::WARN)[1],
+            "Rate limited by text-embedding-3-small: 3 requests throttled in the last 60s, \
+             total backoff 1.5s"
+        );
+    }
+
+    #[test]
+    fn backoff_from_other_transient_errors_is_not_counted() {
+        let tracker = Tracker::default();
+        tracker.record("text-embedding-3-small", Instant::now());
+        record_backoff_on(&tracker, "The server had an error.", Duration::from_secs(5));
+
+        assert_eq!(
+            tracker.lock()["text-embedding-3-small"].backoff,
+            Duration::ZERO
+        );
+    }
+
+    /// The organisation id reaches the per-request detail, as it always has, but
+    /// not the summary.
+    #[test]
+    fn the_summary_carries_no_organisation_id() {
+        let events = Captured::default();
+        let tracker = Tracker::default();
+        let start = Instant::now();
+
+        tracing::subscriber::with_default(events.clone(), || {
+            log_throttled_at(&tracker, TPM_MESSAGE, start);
+            log_throttled_at(&tracker, TPM_MESSAGE, start + Duration::from_secs(30));
+            log_throttled_at(&tracker, TPM_MESSAGE, start + AGGREGATE_WINDOW);
+        });
+
+        assert!(!events.at(Level::WARN)[1].contains("org-"));
+    }
+
+    /// Collects the level and message of every event emitted while it is the
+    /// active subscriber.
+    #[derive(Clone, Default)]
+    struct Captured(Arc<Mutex<Vec<(Level, String)>>>);
+
+    impl Captured {
+        fn at(&self, level: Level) -> Vec<String> {
+            self.0
+                .lock()
+                .expect("the lock is only held by assertions that do not panic")
+                .iter()
+                .filter(|(emitted, _)| *emitted == level)
+                .map(|(_, message)| message.clone())
+                .collect()
+        }
+    }
+
+    impl Subscriber for Captured {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+            Some(tracing::level_filters::LevelFilter::TRACE)
+        }
+
+        fn new_span(&self, _span: &span::Attributes<'_>) -> span::Id {
+            span::Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &span::Id, _values: &span::Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &span::Id, _follows: &span::Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let mut message = String::new();
+            event.record(&mut MessageVisitor(&mut message));
+            self.0
+                .lock()
+                .expect("the lock is only held by assertions that do not panic")
+                .push((*event.metadata().level(), message));
+        }
+
+        fn enter(&self, _span: &span::Id) {}
+
+        fn exit(&self, _span: &span::Id) {}
+    }
+
+    /// Reads the `message` field of an event into a string.
+    struct MessageVisitor<'a>(&'a mut String);
+
+    impl Visit for MessageVisitor<'_> {
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == "message" {
+                self.0.push_str(value);
+            }
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+            if field.name() == "message" {
+                self.0.push_str(&format!("{value:?}"));
+            }
+        }
+    }
+}

--- a/async-openai/src/responses/conversation_items.rs
+++ b/async-openai/src/responses/conversation_items.rs
@@ -32,7 +32,7 @@ impl<'c, C: Config> ConversationItems<'c, C> {
     ) -> Result<ConversationItemList, OpenAIError> {
         self.client
             .post(
-                &format!("/conversations/{}/items", &self.conversation_id),
+                &format!("/conversations/{}/items", self.conversation_id),
                 request,
                 &self.request_options,
             )
@@ -44,7 +44,7 @@ impl<'c, C: Config> ConversationItems<'c, C> {
     pub async fn list(&self) -> Result<ConversationItemList, OpenAIError> {
         self.client
             .get(
-                &format!("/conversations/{}/items", &self.conversation_id),
+                &format!("/conversations/{}/items", self.conversation_id),
                 &self.request_options,
             )
             .await
@@ -55,7 +55,7 @@ impl<'c, C: Config> ConversationItems<'c, C> {
     pub async fn retrieve(&self, item_id: &str) -> Result<ConversationItem, OpenAIError> {
         self.client
             .get(
-                &format!("/conversations/{}/items/{item_id}", &self.conversation_id),
+                &format!("/conversations/{}/items/{item_id}", self.conversation_id),
                 &self.request_options,
             )
             .await
@@ -66,7 +66,7 @@ impl<'c, C: Config> ConversationItems<'c, C> {
     pub async fn delete(&self, item_id: &str) -> Result<ConversationResource, OpenAIError> {
         self.client
             .delete(
-                &format!("/conversations/{}/items/{item_id}", &self.conversation_id),
+                &format!("/conversations/{}/items/{item_id}", self.conversation_id),
                 &self.request_options,
             )
             .await

--- a/async-openai/src/vectorstores/vector_store_file_batches.rs
+++ b/async-openai/src/vectorstores/vector_store_file_batches.rs
@@ -33,7 +33,7 @@ impl<'c, C: Config> VectorStoreFileBatches<'c, C> {
     ) -> Result<VectorStoreFileBatchObject, OpenAIError> {
         self.client
             .post(
-                &format!("/vector_stores/{}/file_batches", &self.vector_store_id),
+                &format!("/vector_stores/{}/file_batches", self.vector_store_id),
                 request,
                 &self.request_options,
             )
@@ -50,7 +50,7 @@ impl<'c, C: Config> VectorStoreFileBatches<'c, C> {
             .get(
                 &format!(
                     "/vector_stores/{}/file_batches/{batch_id}",
-                    &self.vector_store_id
+                    self.vector_store_id
                 ),
                 &self.request_options,
             )
@@ -64,7 +64,7 @@ impl<'c, C: Config> VectorStoreFileBatches<'c, C> {
             .post(
                 &format!(
                     "/vector_stores/{}/file_batches/{batch_id}/cancel",
-                    &self.vector_store_id
+                    self.vector_store_id
                 ),
                 serde_json::json!({}),
                 &self.request_options,
@@ -82,7 +82,7 @@ impl<'c, C: Config> VectorStoreFileBatches<'c, C> {
             .get(
                 &format!(
                     "/vector_stores/{}/file_batches/{batch_id}/files",
-                    &self.vector_store_id
+                    self.vector_store_id
                 ),
                 &self.request_options,
             )

--- a/async-openai/src/vectorstores/vector_store_files.rs
+++ b/async-openai/src/vectorstores/vector_store_files.rs
@@ -35,7 +35,7 @@ impl<'c, C: Config> VectorStoreFiles<'c, C> {
     ) -> Result<VectorStoreFileObject, OpenAIError> {
         self.client
             .post(
-                &format!("/vector_stores/{}/files", &self.vector_store_id),
+                &format!("/vector_stores/{}/files", self.vector_store_id),
                 request,
                 &self.request_options,
             )
@@ -47,7 +47,7 @@ impl<'c, C: Config> VectorStoreFiles<'c, C> {
     pub async fn retrieve(&self, file_id: &str) -> Result<VectorStoreFileObject, OpenAIError> {
         self.client
             .get(
-                &format!("/vector_stores/{}/files/{file_id}", &self.vector_store_id),
+                &format!("/vector_stores/{}/files/{file_id}", self.vector_store_id),
                 &self.request_options,
             )
             .await
@@ -61,7 +61,7 @@ impl<'c, C: Config> VectorStoreFiles<'c, C> {
     ) -> Result<DeleteVectorStoreFileResponse, OpenAIError> {
         self.client
             .delete(
-                &format!("/vector_stores/{}/files/{file_id}", &self.vector_store_id),
+                &format!("/vector_stores/{}/files/{file_id}", self.vector_store_id),
                 &self.request_options,
             )
             .await
@@ -72,7 +72,7 @@ impl<'c, C: Config> VectorStoreFiles<'c, C> {
     pub async fn list(&self) -> Result<ListVectorStoreFilesResponse, OpenAIError> {
         self.client
             .get(
-                &format!("/vector_stores/{}/files", &self.vector_store_id),
+                &format!("/vector_stores/{}/files", self.vector_store_id),
                 &self.request_options,
             )
             .await
@@ -87,7 +87,7 @@ impl<'c, C: Config> VectorStoreFiles<'c, C> {
     ) -> Result<VectorStoreFileObject, OpenAIError> {
         self.client
             .post(
-                &format!("/vector_stores/{}/files/{file_id}", &self.vector_store_id),
+                &format!("/vector_stores/{}/files/{file_id}", self.vector_store_id),
                 request,
                 &self.request_options,
             )
@@ -104,7 +104,7 @@ impl<'c, C: Config> VectorStoreFiles<'c, C> {
             .get(
                 &format!(
                     "/vector_stores/{}/files/{file_id}/content",
-                    &self.vector_store_id
+                    self.vector_store_id
                 ),
                 &self.request_options,
             )


### PR DESCRIPTION
Resolves spiceai/spiceai#12129.

## Problem

Every request in flight is throttled once an organisation's quota saturates, and each one logged a `WARN`. One embedding backfill produced 917 of them in about five minutes, peaking at 356/minute, all identical apart from the token counts. At that volume they crowd out everything else in the log.

Individually the events carry almost no diagnostic value — the client backs off and retries, and the throttling decays on its own. The useful signal is that throttling is happening, at roughly what rate, and for how much cumulative delay.

## Change

`src/client.rs`, on the rate-limited retry path:

- The **first** throttled request per model stays at `WARN`, with the full message, so an operator learns about it immediately.
- Every **later** throttled request drops to `DEBUG`, keeping the per-request detail available without it reaching a default-level log.
- A **per-model summary** is emitted at `WARN` once every 60 seconds:

  ```
  Rate limited by text-embedding-3-small: 500 requests throttled in the last 60s, total backoff 12.4s
  ```

A model that goes a full window without being throttled starts a new episode, so a later bout of throttling is reported at `WARN` again rather than staying silent for up to a minute.

This combines the first two shapes suggested on the issue. The first occurrence at `WARN` is what makes it usable — an operator watching a backfill hears about throttling on the first event rather than up to 60 seconds later — and demoting the rest to `DEBUG` rather than dropping it keeps the per-request detail for anyone who needs it. Rate-limiting the existing line alone (the third suggested shape) would cut the volume but would not carry the count or the cumulative backoff, which is the part that says how much throughput was actually lost.

## Retry and backoff behaviour is unchanged

`backoff::future::retry(b, op)` is defined upstream as `retry_notify(b, op, NoopNotify)`, and `notify` is invoked on the same code path with the exact duration the retry is about to sleep for. Swapping to `retry_notify` therefore changes no scheduling, only what is observed. No retry policy, backoff configuration, or `retry_after` handling is touched.

## Notes

- **Concurrency.** State is a `Mutex<HashMap>` keyed by model, taken only on the throttled path — never on a successful request — so nothing is added to the hot path.
- **Bounded.** Nothing accumulates per request. Models past a fixed limit share one bucket, so unexpected error messages cannot grow the table.
- **No extra sensitive material.** The model is read off the front of the message, so the summary names the model and nothing else; the organisation id appears only where it already did, in the per-request detail.
- **Layering.** No metric is emitted. A counter for throttled requests and cumulative backoff would be useful, but this is a general-purpose crate and should not be wired into a specific consumer's telemetry.

The diff to existing files is 12 lines in `src/client.rs` and 2 in `src/lib.rs`; the rest is a new `src/rate_limit.rs`.

## Tests

12 unit tests in `src/rate_limit.rs`. The clock is a parameter, so windows are exercised deterministically, and each test owns its tracker rather than sharing process state.

Emitted `tracing` events are captured by a test-only `Subscriber`, so the central claim is asserted on real log output: 500 throttle events produce exactly **2** `WARN` lines (the first occurrence plus one summary) and 499 `DEBUG` lines, where previously they produced 500 `WARN` lines.

The rest cover message parsing, per-model separation, backoff accumulating into the open window only and resetting when it closes, backoff from other transient errors not being counted, episode restart after a quiet window, the table staying bounded, and the summary carrying no organisation id.

## Also here: redundant references in `format!` arguments

CI denies warnings, and `clippy::useless_borrows_in_formatting` fires on 14 `format!`
arguments across `src/responses/conversation_items.rs`,
`src/vectorstores/vector_store_files.rs` and `src/vectorstores/vector_store_file_batches.rs`,
where the value is already taken by reference for `Display`. The fix is mechanical — drop the
redundant `&`, as the compiler's own `help:` states — and is a separate commit so it stays
reviewable on its own.

Two things worth knowing about those 14 sites:

**They are unrelated to the logging change, and a toolchain change surfaced them.** PR #37,
whose merge commit is this PR's base, was green on `Build Feature - responses`, `- vectorstore`
and `- full` on 2026-06-29 against this same source. Those three jobs now fail on it under
clippy 1.97. Nothing in the source moved; the lint did. This is not caught on `spiceai` itself
because the workflow only runs on `pull_request`.

**Upstream still has the redundant `&` at all 14 sites**, so this is a deliberate, permanent
local divergence. It should not be reverted back on the next upstream merge.
